### PR TITLE
FRDQ-45 - Adds Google Font Import "Lato" to storybook

### DIFF
--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -1,0 +1,1 @@
+<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Lato">

--- a/src/styles/GlobalStyles.tsx
+++ b/src/styles/GlobalStyles.tsx
@@ -2,7 +2,7 @@ import { createGlobalStyle } from 'styled-components';
 import typography from './typography';
 
 const GlobalStyles = createGlobalStyle`
-body {
+* {
     ${typography.globalStyles}
 }`;
 


### PR DESCRIPTION
Fixes "lato" google font not rendering in storybook - (i had to import it :D)

There is a problem with css font `@type-face` import in styled-components (it downloads the font, but dont use it), so i'm forced to use `preview-head.html`.

Everything is working fine :)

Before and after
![image](https://user-images.githubusercontent.com/9840635/91669261-d6456700-eb13-11ea-9207-43cda3bb9c82.png)
